### PR TITLE
Generic bw.abram() moved to univar. Use method bw.abram.ppp() instead.

### DIFF
--- a/R/smooth_ppp.R
+++ b/R/smooth_ppp.R
@@ -108,7 +108,7 @@ smooth_ppp <- function(data,
     use_h0 <- as.numeric(scott_bw)
     pilot_dens <- density(all_points, sigma = use_h0, kernel = "gaussian") # Density based on h0
 
-    him_points <- spatstat.explore::bw.abram(all_points, h0 = mean(use_h0), at = "points", pilot = pilot_dens) # Bandwidth
+    him_points <- spatstat.explore::bw.abram.ppp(all_points, h0 = mean(use_h0), at = "points", pilot = pilot_dens) # Bandwidth
     num_points <- as.numeric(purrr::map(as.list(data), 2, .default = NA) %>% unlist()) # Num of points for each time frame
     bw_pt <- split(him_points, rep(1 : length(data), num_points))
 


### PR DESCRIPTION
Sorry to bother you again, but we have just moved `bw.abram()` to `spatstat.univar`. You can just call the method `bw.abram.ppp()` from `spatstat.explore`, so it is an easy fix which should work directly on CRAN with current versions of spatstat packages.