### PR TITLE
update function for flexible dimensions

### DIFF
--- a/R/get_em_vec.R
+++ b/R/get_em_vec.R
@@ -4,24 +4,35 @@
 #' `get_em_vec()` get the vector form of a column of a hyperframe that summarizes the effect modifier data in heterogeneity analysis
 #'
 #' @param em column of a hyperframe that summarizes effect modifier data. In the form of `hyperframe$column`.
+#' @param outcome_pixel_count
+#'   A list of integer-valued pixel images giving outcome event counts per spatial pixel,
+#'   typically obtained from `pixel_count_ppp()`.
 #' @param time_after whether to include one unit time difference between treatment and outcome. By default = TRUE
 #' @param lag integer that specifies lags to calculate causal estimates
 #' @param entire_window owin object (the entire region of interest). If given, then the values outside the region will be set to `NA`.
-#' @param ngrid a number or a vector of two numbers that specify the dimension of pixels. If NULL, the pixel dimension of the original
-#' images will not be changed
-#' 
+#'
 #' @details The function `get_em_vec()` get the vector form of the effect modifier in the heterogeneity analysis. It is useful
 #' if you want to construct the variance matrix `E_mat` that is passed to the function `get_cate()`
-
-
-get_em_vec <- function(em,time_after = TRUE,lag,entire_window = NULL,ngrid=NULL){
-  if(length(ngrid)==1){
-    ngrid <- rep(ngrid,2)
-  }
-  l <- length(em)
-  res <- imls_to_arr(em,start=1,end=l-time_after-lag+1,entire_window,ngrid = ngrid)
-  res <- c(res)
+get_em_vec <- function(em,
+                       outcome_pixel_count = NULL,
+                       time_after = TRUE,
+                       entire_window = NULL,
+                       lag) {
   
+  
+  if (is.null(outcome_pixel_count)) {
+    stop("`outcome_pixel_count` must be provided to determine the pixel grid.")
+  }
+
+  l <- length(em)
+  dimyx <- dim(outcome_pixel_count[[1]])
+
+  res <- imls_to_arr(em,
+                     start = 1,
+                     end = l - time_after - lag + 1,
+                     entire_window = entire_window,
+                     dimyx = dimyx)
+  
+  res <- c(res)
   return(res)
 }
-

--- a/R/imls_to_arr.R
+++ b/R/imls_to_arr.R
@@ -6,47 +6,45 @@
 #' @param imls a list of im objects (imlist)
 #' @param start the index of the first im to be converted. Default is 1.
 #' @param end the index of the last im to be converted. If not provided, then it will be set to the length of the list.
-#' @param entire_window a owin object. If given, then the values outside the region will be set to `NA`
-#' @param ngrid  an optional arugument that takes one integer or  vector of two integers specifying the dimensions of the `im` objects. If provided, the dimensions of the objects will be adjusted to `ngrid` before the conversion to the array.
+#' @param entire_window a owin object. If given, then the values outside the region will be set to `NA`.
+#' @param ... Additional arguments passed to spatstat conversion functions.
 #' 
 #' @details `imls_to_arr()` is a internal function for `imls_to_vec()`. By default, it returns a three-dimensional array of dimension \eqn{n} by \eqn{m} by\eqn{l} where \eqn{n} and \eqn{m}
-#' are the dimensions of the im objects, and \eqn{l} is the length of the list. All the im objects in the list need to have the same dimensions. 
-
-imls_to_arr <- function(imls,start = 1,end = NULL,entire_window = NULL,ngrid = NULL){
-  adjust_dim <- TRUE
+#' are the dimensions of the im objects, and \eqn{l} is the length of the list. All the im objects in the list need to have the same dimensions.
+imls_to_arr <- function(imls,
+                        start = 1,
+                        end = NULL,
+                        entire_window = NULL,...) {
   
-  if(is.null(end)){
+  
+  if (is.null(end)) {
     end <- length(imls)
   }
   
-  if(is.null(ngrid)){
-    ngrid <- dim(imls[[1]])
-    adjust_dim <- FALSE
-  }
-  if(length(ngrid)==1){
-    ngrid <- rep(ngrid,2)
-  }
+  if (!is.null(entire_window)) {
+    window_matrix <- spatstat.geom::as.matrix.owin(entire_window, ...)
+    window_matrix[window_matrix == 0] <- NA
     
-  if(!is.null(entire_window)){
-    window_matrix <- spatstat.geom::as.matrix.owin(entire_window,dimyx = ngrid)
-    window_matrix[window_matrix==0] <- NA
-    if(adjust_dim){
-      imls <- lapply(start:end, function(x) spatstat.geom::as.matrix.im(spatstat.geom::as.im(imls[[x]],dimyx = ngrid))*window_matrix)
-    }else{
-      imls <- lapply(start:end, function(x) spatstat.geom::as.matrix.im(imls[[x]])*window_matrix)
-    }
     
-  }else{
-    if(adjust_dim){
-      imls <- lapply(start:end, function(x) spatstat.geom::as.matrix.im(spatstat.geom::as.im(imls[[x]],dimyx = ngrid)))
-    }else{
-      imls <- lapply(start:end, function(x) spatstat.geom::as.matrix.im(imls[[x]]))
-    }
+    imls <- lapply(start:end, function(x) {
+      spatstat.geom::as.matrix.im(
+        spatstat.geom::as.im(imls[[x]], ...)
+      ) * window_matrix
+    })
+     
+    
+  } else {
+    
+ 
+    imls <- lapply(start:end, function(x) {
+      spatstat.geom::as.matrix.im(
+        spatstat.geom::as.im(imls[[x]],...)
+      )
+    })
+  
     
   }
   
-  imls <- array(unlist(imls),c(dim(imls[[1]]),end-start+1))
-  
+  imls <- array(unlist(imls), c(dim(imls[[1]]), end - start + 1))
   return(imls)
 }
-

--- a/R/pixel_count_ppp.R
+++ b/R/pixel_count_ppp.R
@@ -6,7 +6,8 @@
 #' @param data the name of a hyperframe and column of interest.
 #' @param W Optional window mask (object of class `"owin"`) determining the pixel raster.
 #' `data` should be in the form of `"hyperframe$column"`.
-#' @param ngrid a number or a vector of two numbers specifying the pixel array dimensions. A single integer, or an integer vector of length 2 giving dimensions in the y and x directions.Default is `c(128,128)`.
+#' @param resolution resolution of raster (distance map) (in km)
+#' @param ndim the number of dimensions of grid cells (ndim^2). Users need to set either resolution or ndim.
 #' @param weights Optional vector of weights associated with the points.
 #' @param DivideByPixelArea Logical value determining whether the resulting pixel values should be devided by the pixel area. Default value is `False`.
 #' @param ... parameters passed on to the function.
@@ -31,11 +32,42 @@
 #' # Get the number of events for each pixel
 #' pixel_count_ppp(data = dat_hfr$all_combined)
 
-pixel_count_ppp <- function(data,ngrid = c(128,128), W=NULL, weights = NULL,DivideByPixelArea = FALSE,...) {
-  if(length(ngrid)==1){
-    ngrid <- rep(ngrid,2)
+pixel_count_ppp <- function(data, resolution = NULL,
+                            ndim = NULL, W=NULL, weights = NULL,DivideByPixelArea = FALSE,...) {
+  
+  # Get window from first ppp object
+  window <- if (!is.null(W)) W else data[[1]]$window
+  
+  
+  # Determine output dimensions based on parameters
+  if (!is.null(ndim)) {
+    # Pixel mode: fixed dimensions
+    dimyx <- c(ndim, ndim)
+    message("Using pixel mode: ", ndim, "x", ndim, " pixels\n")
+  } else if (!is.null(resolution)) {
+    # Resolution mode: km per pixel
+    x_extent <- diff(window$xrange)
+    y_extent <- diff(window$yrange)
+    nc <- ceiling(x_extent / resolution)
+    nr <- ceiling(y_extent / resolution)
+    dimyx <- c(nr, nc)
+    message("Using resolution mode: ", resolution, " km per pixel -> ", nr, "x", nc, " pixels\n")
+  } else {
+    # Default: 128x128
+    dimyx <- c(128, 128)
+    message("Using default dimensions: 128x128 pixels\n")
   }
-  pixel_count <- furrr::future_map(data, spatstat.geom::pixellate.ppp,dimyx = ngrid,W = W, weights = weights, DivideByPixelArea = DivideByPixelArea,...)
+  
+  # avoid passing W twice if user included it in ...
+  dots <- list(...)
+  if ("W" %in% names(dots)) {
+    stop("Do not pass `W` via `...`; use the explicit `W =` argument.")
+  }
+  if ("dimyx" %in% names(dots)) {
+    stop("Do not pass `dimyx` via `...`; use `resolution`/`ndim` instead.")
+  }
+  
+  pixel_count <- furrr::future_map(data, spatstat.geom::pixellate.ppp,dimyx = dimyx,W = W, weights = weights, DivideByPixelArea = DivideByPixelArea,...)
   
   return(pixel_count)
   

--- a/man/get_em_vec.Rd
+++ b/man/get_em_vec.Rd
@@ -4,19 +4,25 @@
 \alias{get_em_vec}
 \title{convert a list of im objects to a vector}
 \usage{
-get_em_vec(em, time_after = TRUE, lag, entire_window = NULL, ngrid = NULL)
+get_em_vec(
+  em,
+  outcome_pixel_count = NULL,
+  time_after = TRUE,
+  entire_window = NULL,
+  lag
+)
 }
 \arguments{
 \item{em}{column of a hyperframe that summarizes effect modifier data. In the form of `hyperframe$column`.}
 
-\item{time_after}{whether to include one unit time difference between treatment and outcome. By default = TRUE}
+\item{outcome_pixel_count}{A list of integer-valued pixel images giving outcome event counts per spatial pixel,
+typically obtained from `pixel_count_ppp()`.}
 
-\item{lag}{integer that specifies lags to calculate causal estimates}
+\item{time_after}{whether to include one unit time difference between treatment and outcome. By default = TRUE}
 
 \item{entire_window}{owin object (the entire region of interest). If given, then the values outside the region will be set to `NA`.}
 
-\item{ngrid}{a number or a vector of two numbers that specify the dimension of pixels. If NULL, the pixel dimension of the original
-images will not be changed}
+\item{lag}{integer that specifies lags to calculate causal estimates}
 }
 \description{
 `get_em_vec()` get the vector form of a column of a hyperframe that summarizes the effect modifier data in heterogeneity analysis

--- a/man/imls_to_arr.Rd
+++ b/man/imls_to_arr.Rd
@@ -4,7 +4,7 @@
 \alias{imls_to_arr}
 \title{convert a list of im objects to a three-dimensional array}
 \usage{
-imls_to_arr(imls, start = 1, end = NULL, entire_window = NULL, ngrid = NULL)
+imls_to_arr(imls, start = 1, end = NULL, entire_window = NULL, ...)
 }
 \arguments{
 \item{imls}{a list of im objects (imlist)}
@@ -13,9 +13,9 @@ imls_to_arr(imls, start = 1, end = NULL, entire_window = NULL, ngrid = NULL)
 
 \item{end}{the index of the last im to be converted. If not provided, then it will be set to the length of the list.}
 
-\item{entire_window}{a owin object. If given, then the values outside the region will be set to `NA`}
+\item{entire_window}{a owin object. If given, then the values outside the region will be set to `NA`.}
 
-\item{ngrid}{an optional arugument that takes one integer or  vector of two integers specifying the dimensions of the `im` objects. If provided, the dimensions of the objects will be adjusted to `ngrid` before the conversion to the array.}
+\item{...}{Additional arguments passed to spatstat conversion functions.}
 }
 \description{
 `imls_to_arr()` convert a list of im object to a 3D array

--- a/man/pixel_count_ppp.Rd
+++ b/man/pixel_count_ppp.Rd
@@ -6,7 +6,8 @@
 \usage{
 pixel_count_ppp(
   data,
-  ngrid = c(128, 128),
+  resolution = NULL,
+  ndim = NULL,
   W = NULL,
   weights = NULL,
   DivideByPixelArea = FALSE,
@@ -16,7 +17,9 @@ pixel_count_ppp(
 \arguments{
 \item{data}{the name of a hyperframe and column of interest.}
 
-\item{ngrid}{a number or a vector of two numbers specifying the pixel array dimensions. A single integer, or an integer vector of length 2 giving dimensions in the y and x directions.Default is `c(128,128)`.}
+\item{resolution}{resolution of raster (distance map) (in km)}
+
+\item{ndim}{the number of dimensions of grid cells (ndim^2). Users need to set either resolution or ndim.}
 
 \item{W}{Optional window mask (object of class `"owin"`) determining the pixel raster.
 `data` should be in the form of `"hyperframe$column"`.}


### PR DESCRIPTION
Main changes:

1. Update pixel_count_ppp(), get_em_vec(), and the utility function imls_to_arr() to use a consistent pixel dimension specification aligned with other functions.
2. The pixel grid used in heterogeneity analysis is now determined by the outcome pixel counts returned by pixel_count_ppp(), and get_em_vec() enforces that effect-modifier images are resized to match this grid.